### PR TITLE
Broken max width

### DIFF
--- a/amp.safariextension/Info.plist
+++ b/amp.safariextension/Info.plist
@@ -5,7 +5,7 @@
 	<key>Author</key>
 	<string>Ed Lea</string>
 	<key>Builder Version</key>
-	<string>11601.1.56</string>
+	<string>11601.6.17</string>
 	<key>CFBundleDisplayName</key>
 	<string>⚡️</string>
 	<key>CFBundleIdentifier</key>
@@ -13,9 +13,9 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2</string>
+	<string>2.3</string>
 	<key>CFBundleVersion</key>
-	<string>2.2</string>
+	<string>2.3</string>
 	<key>Content</key>
 	<dict>
 		<key>Scripts</key>
@@ -29,7 +29,7 @@
 	<key>Description</key>
 	<string>Load the AMP version of a page if available</string>
 	<key>DeveloperIdentifier</key>
-	<string>L7VLS57JHX</string>
+	<string>0000000000</string>
 	<key>ExtensionInfoDictionaryVersion</key>
 	<string>1.0</string>
 	<key>Permissions</key>

--- a/amp.safariextension/amp.js
+++ b/amp.safariextension/amp.js
@@ -1,5 +1,5 @@
 var docEl = document.documentElement;
-var isAMP = docEl.hasAttribute('amp') || docEl.hasAttribute('⚡') || docEl.hasAttribute('⚡️');
+var isAMP = docEl.hasAttribute('amp') || docEl.hasAttribute('⚡');
 var observerConfig = { childList: true, subtree: true };
 
 var documentObserver = observeNode(docEl, inspectDocNodes);

--- a/amp.safariextension/amp.js
+++ b/amp.safariextension/amp.js
@@ -1,5 +1,5 @@
 var docEl = document.documentElement;
-var isAMP = docEl.hasAttribute('amp') || docEl.hasAttribute('⚡️');
+var isAMP = docEl.hasAttribute('amp') || docEl.hasAttribute('⚡') || docEl.hasAttribute('⚡️');
 var observerConfig = { childList: true, subtree: true };
 
 var documentObserver = observeNode(docEl, inspectDocNodes);
@@ -46,11 +46,11 @@ function queryForMeta(head) {
 }
 
 function redirect(node) {
-  window.location = node.getAttribute("href");
+    window.location = node.getAttribute("href");
 }
 
 function applyMobileCSS(node) {
-  var css = "body > * { max-width: 600px; margin: 0px auto; }";
+  var css = "body > * { max-width: 600px; margin: 0px auto !important; }";
   var style = document.createElement('style');
   style.type = 'text/css';
   style.appendChild(document.createTextNode(css));

--- a/chrome/amp.js
+++ b/chrome/amp.js
@@ -1,5 +1,5 @@
 var docEl = document.documentElement;
-var isAMP = docEl.hasAttribute('amp') || docEl.hasAttribute('⚡') || docEl.hasAttribute('⚡️');
+var isAMP = docEl.hasAttribute('amp') || docEl.hasAttribute('⚡');
 var observerConfig = { childList: true, subtree: true };
 
 var documentObserver = observeNode(docEl, inspectDocNodes);

--- a/chrome/amp.js
+++ b/chrome/amp.js
@@ -1,5 +1,5 @@
 var docEl = document.documentElement;
-var isAMP = docEl.hasAttribute('amp') || docEl.hasAttribute('⚡️');
+var isAMP = docEl.hasAttribute('amp') || docEl.hasAttribute('⚡') || docEl.hasAttribute('⚡️');
 var observerConfig = { childList: true, subtree: true };
 
 var documentObserver = observeNode(docEl, inspectDocNodes);
@@ -50,7 +50,7 @@ function redirect(node) {
 }
 
 function applyMobileCSS(node) {
-  var css = "body > * { max-width: 600px; margin: 0px auto; }";
+  var css = "body > * { max-width: 600px; margin: 0px auto !important; }";
   var style = document.createElement('style');
   style.type = 'text/css';
   style.appendChild(document.createTextNode(css));

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -2,7 +2,7 @@
   "name": "⚡️ Desktop AMP",
   "description": "Load the AMP version of a page if available",
   "author": "Ed Lea",
-  "version": "2.2",
+  "version": "2.3",
   "content_scripts": [{
     "js": ["amp.js"],
     "run_at": "document_start",


### PR DESCRIPTION
Some editor somewhere was corrupting the ⚡ character used to indicate
an AMP page on some sites. This stopped the "max-width" hack from
being applied.

Also make the max-width hack "!important"
