### PR TITLE
fix rel toLowerCase exception

### DIFF
--- a/src/amp.js
+++ b/src/amp.js
@@ -31,7 +31,12 @@ function inspectDocNodes(node){
 }
 
 function inspectHeadNodes(node) {
-  if (node.tagName == "LINK" && node.getAttribute('rel').toLowerCase() == 'amphtml') {
+  if (node.tagName !== "LINK") return;
+
+  var rel = node.getAttribute('rel');
+  if (!rel) return;
+
+  if (rel.toLowerCase() == 'amphtml') {
       headObserver.disconnect();
       redirect(node);
   }


### PR DESCRIPTION
On twitter.com I'm getting this exception:
![image](https://cloud.githubusercontent.com/assets/39191/26135262/3abc9fb4-3a69-11e7-9a6a-5fafeffb04e9.png)


Admittedly, the code is a bit optimistic on expecting a `rel` value.

